### PR TITLE
Simplify TimeKeeper

### DIFF
--- a/src/Helper/TimeKeeper.php
+++ b/src/Helper/TimeKeeper.php
@@ -20,10 +20,15 @@ declare(strict_types=1);
 
 namespace Automattic\SlidingWindowCounter\Helper;
 
-interface TimeKeeper
+use function time;
+
+class TimeKeeper
 {
     /**
      * A mockable time-getter for the current time.
      */
-    public function getCurrentUnixTime(): int;
+    public function getCurrentUnixTime(): int
+    {
+        return time();
+    }
 }

--- a/src/SlidingWindowCounter.php
+++ b/src/SlidingWindowCounter.php
@@ -26,7 +26,6 @@ use Pipeline\Standard;
 use function is_int;
 use function Pipeline\take;
 use function sprintf;
-use function time;
 
 /**
  * Sliding window counter and time series.
@@ -42,7 +41,7 @@ class SlidingWindowCounter
     /** @var int Maximum number of seconds for the buckets to last in cache. */
     private int $observation_period;
 
-    /** @var \Automattic\SlidingWindowCounter\Cache\CounterCache The counter cache instance */
+    /** @var Cache\CounterCache The counter cache instance */
     private Cache\CounterCache $counter_cache;
 
     /** @var Helper\TimeKeeper The timekeeper instance. */
@@ -91,12 +90,7 @@ class SlidingWindowCounter
         $this->counter_cache = $counter_cache;
 
         // Optional dependencies
-        $this->time_keeper = $time_keeper ?? new class() implements Helper\TimeKeeper {
-            public function getCurrentUnixTime(): int
-            {
-                return time();
-            }
-        };
+        $this->time_keeper = $time_keeper ?? new Helper\TimeKeeper();
 
         $this->frame_builder = $frame_builder ?? new Helper\FrameBuilder($window_size, $observation_period, $this->time_keeper);
     }

--- a/tests/Helper/FakeTimeKeeper.php
+++ b/tests/Helper/FakeTimeKeeper.php
@@ -22,7 +22,7 @@ namespace Tests\Automattic\SlidingWindowCounter\Helper;
 
 use Automattic\SlidingWindowCounter\Helper\TimeKeeper;
 
-class FakeTimeKeeper implements TimeKeeper
+class FakeTimeKeeper extends TimeKeeper
 {
     private int $time;
 


### PR DESCRIPTION
We shouldn't need an interface since this is the only place where we use it. A plain instance should suffice.