### PR TITLE
Fix nullable parameter declarations for PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "johnpbloch/wordpress-core": "^6.2",
         "phan/phan": ">=1.1",
         "phpstan/phpstan": ">=0.10",
-        "phpunit/phpunit": ">=9.4",
+        "phpunit/phpunit": "^9.4 || ^10.0",
         "vimeo/psalm": ">=2"
     },
     "autoload": {

--- a/src/SlidingWindowCounter.php
+++ b/src/SlidingWindowCounter.php
@@ -69,8 +69,8 @@ class SlidingWindowCounter
         int $window_size,
         int $observation_period,
         Cache\CounterCache $counter_cache,
-        Chorus\TimeKeeper $time_keeper = null,
-        Helper\FrameBuilder $frame_builder = null
+        ?Chorus\TimeKeeper $time_keeper = null,
+        ?Helper\FrameBuilder $frame_builder = null
     ) {
         if ('' === $cache_name) {
             throw new InvalidArgumentException('Cache name expected to be a non-blank string');


### PR DESCRIPTION
## What and why?
PHP 8.4 requires explicit nullable type declarations using the `?` prefix for parameters that can accept null values. The current code in `SlidingWindowCounter` constructor uses `= null` without the nullable type prefix, which will cause deprecation warnings or errors in PHP 8.4.

Updated the constructor parameters:
- Changed `Chorus\TimeKeeper $time_keeper = null` to `?Chorus\TimeKeeper $time_keeper = null`
- Changed `Helper\FrameBuilder $frame_builder = null` to `?Helper\FrameBuilder $frame_builder = null`

Additionally, constrained PHPUnit version to `^9.4 || ^10.0` to prevent CI failures. The previous `>=9.4` constraint was allowing PHPUnit 12 to be installed, which requires data providers to use PHP attributes instead of PHPDoc annotations, causing test failures unrelated to any code changes.

## Testing
- All existing tests pass
- The changes are backward compatible with PHP 8.1+
- No functional changes, only type declaration syntax updates